### PR TITLE
Enable scanning from manifest paths

### DIFF
--- a/.resourcely.gitlab-ci.yml
+++ b/.resourcely.gitlab-ci.yml
@@ -16,6 +16,7 @@ variables:
   RESOURCELY_API_HOST: "https://api.resourcely.io"
   RESOURCELY_IMAGE: "latest"
   RESOURCELY_DEBUG: "false"
+  RESOURCELY_MANIFEST_PATH: ""
 
 workflow:
   rules:
@@ -26,11 +27,15 @@ resourcely_guardrails:
   image: 
     name: ghcr.io/resourcely-inc/resourcely-cli:$RESOURCELY_IMAGE
     entrypoint: [""]
-  before_script:
-    - sh locate-plans.sh
-    - export PLANS=$(ls -1 $TF_PLAN_DIRECTORY/$TF_PLAN_PATTERN | tr '\r\n' ',' | sed -e 's/,$/\n/')
   script:
-    - /resourcely-cli evaluate --change_request_url $CHANGE_REQUEST_URL --change_request_sha $CI_COMMIT_SHA --plan $PLANS
+    - >
+      if [[ -z "${RESOURCELY_MANIFEST_PATH}" ]]; then
+        sh locate-plans.sh
+        export PLANS=$(ls -1 $TF_PLAN_DIRECTORY/$TF_PLAN_PATTERN | tr '\r\n' ',' | sed -e 's/,$/\n/')
+        /resourcely-cli evaluate --change_request_url $CHANGE_REQUEST_URL --change_request_sha $CI_COMMIT_SHA --plan $PLANS
+      else
+        /resourcely-cli evaluate --change_request_url $CHANGE_REQUEST_URL --change_request_sha $CI_COMMIT_SHA --plan_manifest $RESOURCELY_MANIFEST_PATH
+      fi
   allow_failure: true
   rules:
     - if: '$CI_PIPELINE_SOURCE == "merge_request_event"'

--- a/.resourcely.gitlab-ci.yml
+++ b/.resourcely.gitlab-ci.yml
@@ -31,7 +31,7 @@ resourcely_guardrails:
     - >
       if [[ -z "${RESOURCELY_MANIFEST_PATH}" ]]; then
         sh locate-plans.sh
-        export PLANS=$(ls -1 $TF_PLAN_DIRECTORY/$TF_PLAN_PATTERN | tr '\r\n' ',' | sed -e 's/,$/\n/')
+        export PLANS=$(ls -1 "$TF_PLAN_DIRECTORY"/"$TF_PLAN_PATTERN" | tr '\r\n' ',' | sed -e 's/,$/\n/')
         /resourcely-cli evaluate --change_request_url $CHANGE_REQUEST_URL --change_request_sha $CI_COMMIT_SHA --plan $PLANS
       else
         /resourcely-cli evaluate --change_request_url $CHANGE_REQUEST_URL --change_request_sha $CI_COMMIT_SHA --plan_manifest $RESOURCELY_MANIFEST_PATH

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ In order to add the Resourcely guardrail validation job to your GitLab pipeline,
 Once a new Resource has been created via Merge-Request, the Resourcely job will automatically kick-off. It runs in
 the **test** stage by default.
 
-## Template Configuration
+## Configuration Variables
 
 The Resourcely template can be customized by overwriting the following variables in your `.gitlab-ci.yml`:
 
@@ -66,16 +66,107 @@ The Resourcely template can be customized by overwriting the following variables
 | RESOURCELY_API_HOST | The Resourcely API host | "https://api.resourcely.io" |
 | RESOURCELY_IMAGE | The Resourcely container image version | "latest" |
 | RESOURCELY_DEBUG | Enable debug mode | "false" |
+| RESOURCELY_MANIFEST_PATH | The location of a Resourcely manifest file; If set will scan the directories present in the manifest and ignore `TF_PLAN_DIRECTORY` and `TF_PLAN_PATTERN` | "" |
 
-Additionally you can run the Resourcely guardrail job in another stage by overwriting the job definition in your
-`.gitlab-ci.yml`. The following example sets the Resourcely guardrail job to run in a stage named **security**, and sets the `TF_PLAN_DIRECTORY` to **/plans**:
+## How to Configure
+
+You can override the `resourcely_guardrails` job definition within your project's `.gitlab-ci.yml`.
+
+The following: 
+
+- Sets the Resourcely guardrail job to run in a stage named **security**
+- Sets the `TF_PLAN_DIRECTORY` to **/plans** telling Resourcely to look for plans in the **/plans** directory
+- Sets the `TF_PLAN_PATTERN` to **"*.json"** telling Resourcely to scan all **json** files
+- Sets `allow_failure` to false, meaning if the `resourcely_guardrails` job fails, then the pipeline will not proceed
 
 ```yaml
 stages:
   - security
 
+include:
+  - remote: 'https://raw.githubusercontent.com/Resourcely-Inc/resourcely-gitlab-template/main/.resourcely.gitlab-ci.yml'
+
 resourcely_guardrails:
   stage: security
   variables:
     TF_PLAN_DIRECTORY: /plans
+    TF_PLAN_PATTERN: "*.json"
+  allow_failure: false
 ```
+
+### Scanning for plans generated in multiple directories
+
+The `resourcely_guardrails` job can scan Terraform plans in multiple directories. This can be done by creating a
+manifest json as follows:
+
+```json
+{
+  "plans": [{
+    "plan_file": "dev/plan.json",
+    "config_root_path": "dev"
+  },{
+    "plan_file": "prod/plan.json",
+    "config_root_path": "prod"
+  }]
+}
+```
+
+A manifest is a list of plans composed of the following directives:
+
+* **plan_file**: The full path to where the Terraform plan file will be generated
+* **config_root_path**: the directory from where your Terraform plan is generated
+
+Then you must set the `RESOURCELY_MANIFEST_PATH` to the location of the manifest json: 
+
+```yaml
+stages:
+  - test
+
+variables:
+  RESOURCELY_MANIFEST_PATH: /path/to/manifest.json
+
+include:
+  - remote: 'https://raw.githubusercontent.com/Resourcely-Inc/resourcely-gitlab-template/main/.resourcely.gitlab-ci.yml'
+```
+
+Then Resourcely will scan the plans defined in the manifest. Note that with the GitLab
+project, the root (/) is at [$CI_PROJECT_DIR](https://docs.gitlab.com/ee/ci/variables/predefined_variables.html).
+
+#### Generating/Downloading the manifest file in GitLab
+
+Additionally you can generate the manifest file in GitLab before the `resourcely_guardrail` job is run.
+This can be done as follows:
+
+```yaml
+stages:
+  - manifest
+  - test
+
+variables:
+  RESOURCELY_MANIFEST_PATH: manifest.json
+
+include:
+  - remote: 'https://raw.githubusercontent.com/Resourcely-Inc/resourcely-gitlab-template/main/.resourcely.gitlab-ci.yml'
+
+generate_manifest:
+  stage: manifest
+  script:
+    - |
+      cat > manifest.json << EOF
+      {
+      "plans": [{
+      "plan_file": "dev/plan.json",
+      "config_root_path": "dev"
+      },{
+      "plan_file": "prod/plan.json",
+      "config_root_path": "prod"
+      }]
+      }
+      EOF
+  artifacts:
+    paths:
+      - manifest.json
+```
+
+This will generate a manifest json and store it as an artifact which the `resourcely_guardrails` job
+can access.


### PR DESCRIPTION
Adds directives and instructions to allow the resourcely guardrail check to scan plans using the paths found in a manifest. Allows for scanning multiple plans in different directories.