### PR TITLE
Remove quotes from PLAN_PATTERN variable

### DIFF
--- a/.resourcely.gitlab-ci.yml
+++ b/.resourcely.gitlab-ci.yml
@@ -31,7 +31,7 @@ resourcely_guardrails:
     - >
       if [[ -z "${RESOURCELY_MANIFEST_PATH}" ]]; then
         sh locate-plans.sh
-        export PLANS=$(ls -1 "$TF_PLAN_DIRECTORY"/"$TF_PLAN_PATTERN" | tr '\r\n' ',' | sed -e 's/,$/\n/')
+        export PLANS=$(ls -1 "$TF_PLAN_DIRECTORY"/$TF_PLAN_PATTERN | tr '\r\n' ',' | sed -e 's/,$/\n/')
         /resourcely-cli evaluate --change_request_url $CHANGE_REQUEST_URL --change_request_sha $CI_COMMIT_SHA --plan $PLANS
       else
         /resourcely-cli evaluate --change_request_url $CHANGE_REQUEST_URL --change_request_sha $CI_COMMIT_SHA --plan_manifest $RESOURCELY_MANIFEST_PATH


### PR DESCRIPTION
Removes quotes from PLAN_PATTERN variable which causes the ls to take the pattern literally and not use regex.